### PR TITLE
Added the host status url to the notification messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Nagios notifications for Slack, with formatted messages :
 
 * Edit the Slack URLs in both scripts to reflect the webhooks you created in Slack.
 
+* Edit yout nagios host full qualified domain name on both scripts.
+
 * Define the new notification commands in Nagios.
 ( see examples in slack_commands.cfg, modify any paths as required)
 

--- a/slack_host_notify.sh
+++ b/slack_host_notify.sh
@@ -3,6 +3,9 @@
 # Edit your Slack hook URL and footer icon URL
 SLACK_URL=https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
 FOOTER_ICON=http://env.baarnes.com/Nagios.png
+NAGIOSFQDN=YOUR_NAGIOS_FQDN
+HOSTURL=https://$NAGIOSFQDN/nagios/cgi-bin/status.cgi?host=
+
 
 # Host Notification command example :
 
@@ -28,7 +31,7 @@ IFS='%'
 
 SLACK_MSG="payload={\"attachments\":[{\"color\": \"$MSG_COLOR\",\"title\": \"Host $1 notification\",
 \"text\": \"Host:        $2\\nIP:             $3\\nState:        $4\"},
-{\"color\": \"$MSG_COLOR\",\"title\":\"Additional Info :\",\"text\":\"\\n$5\",
+{\"color\": \"$MSG_COLOR\",\"title\":\"Additional Info :\",\"text\":\"\\n$5 \\nUrl:            $HOSTURL$2\",
 \"footer\": \"Nagios notification: $6\",\"footer_icon\": \"$FOOTER_ICON\"}]}"
 
 #Send message to Slack

--- a/slack_service_notify.sh
+++ b/slack_service_notify.sh
@@ -3,7 +3,8 @@
 # Edit your Slack hook URL and footer icon URL
 SLACK_URL=https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
 FOOTER_ICON=http://env.baarnes.com/Nagios.png
-
+NAGIOSFQDN=YOUR_NAGIOS_FQDN
+HOSTURL=https://$NAGIOSFQDN/nagios/cgi-bin/status.cgi?host=
 # Service Notification command example :
 
 # define command {
@@ -31,7 +32,7 @@ IFS='%'
 
 SLACK_MSG="payload={\"attachments\":[{\"color\": \"$MSG_COLOR\",\"title\": \"Service $1 notification\",
 \"text\": \"Host:        $2\\nIP:             $3\\nService:    $4\\nState:        $5\"},
-{\"color\": \"$MSG_COLOR\",\"title\":\"Additional Info :\",\"text\":\"\\n$6\",
+{\"color\": \"$MSG_COLOR\",\"title\":\"Additional Info :\",\"text\":\"\\n$6 \\nUrl:            $HOSTURL$2\",
 \"footer\": \"Nagios notification: $7\",\"footer_icon\": \"$FOOTER_ICON\"}]}"
 
 #Send message to Slack


### PR DESCRIPTION
Added the host status url to the notification messages.
By adding the host status url to the message we can immediately check the status of all probes from the host that triggered the warning.
Just a tweak that I found helpfull.